### PR TITLE
Fix ember commands launchs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.2.3",
   "publisher": "felixrieseberg",
   "engines": {
-    "vscode": "^0.10.0"
+    "vscode": "^1.1.0"
   },
   "license": "MIT",
   "categories": [
@@ -109,6 +109,7 @@
     ]
   },
   "scripts": {
+    "postinstall": "node ./node_modules/vscode/bin/install",
     "vscode:prepublish": "tsc && node ./node_modules/vscode/bin/compile",
     "compile": "tsc && node ./node_modules/vscode/bin/compile -watch -p ./",
     "test": "tslint ./src/*"
@@ -116,7 +117,7 @@
   "devDependencies": {
     "tslint": "^3.2.0",
     "typescript": "^1.7.3",
-    "vscode": "^0.10.6"
+    "vscode": "^0.11.12"
   },
   "dependencies": {
     "fs-extra": "^0.26.7",

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -108,9 +108,6 @@ export class EmberOperation {
 
             this._process.on("close", (code) => {
                 this._oc.appendLine(`Ember ${this.cmd[0]} process exited with code ${code}`);
-                if (this._isOutputChannelVisible) {
-                    this._oc.hide();
-                }
 
                 resolve(<EmberOperationResult>{
                     code: parseInt(code),

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -79,6 +79,7 @@ export class EmberOperation {
                     cwd: workspace.rootPath
                 });
             }
+            this._oc.appendLine("Building...");
 
             if (this._isOutputChannelVisible || debugEnabled) {
                 this._isOutputChannelVisible = true;

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -63,7 +63,7 @@ export class EmberOperation {
             let debugEnabled = process.env.VSC_EMBER_CLI_DEBUG || process.env["VSC EMBER CLI DEBUG"];
 
             this._oc = window.createOutputChannel(`Ember: ${capitalizeFirstLetter(this.cmd[0])}`);
-
+            
             // On Windows, we'll have to call Ember with PowerShell
             // https://github.com/nodejs/node-v0.x-archive/issues/2318
             if (os.platform() === "win32") {
@@ -71,7 +71,8 @@ export class EmberOperation {
                 joinedArgs.unshift("ember");
 
                 this._process = this._spawn("powershell.exe", joinedArgs, {
-                    cwd: workspace.rootPath
+                    cwd: workspace.rootPath,
+                    stdio: ['ignore', 'pipe', 'pipe' ]
                 });
             } else {
                 this._process = this._spawn("ember", this.cmd, {


### PR DESCRIPTION
The intent of this PR is to fix ember commands launchs in Windows (see #13).

It appears that powershell requires an explicit binding of its outputs to the child process ones. Without that configuration, "data" event were never received by child process and vscode console output was never updated.

Doing this, it seemed relevant to me to make some complementary changes : 
- Upgrade vscode version to 0.11.12 to match current release
- Keep the console open after task because I think that this is non obvious the task ran if we could not see it results
- Add initial message immediately after spawn to give an immediate feedback to the user in order to show him that something is running

Let me know if this could be suitable for you and do not hesitate to picke only some of these changes if you think some of them are irrelevant.

This should fix #13.

I hope it'll help.
