### PR TITLE
Fix blueprint generators and include all available blueprints

### DIFF
--- a/src/dumb-cache.ts
+++ b/src/dumb-cache.ts
@@ -21,7 +21,14 @@ export default class DumbCache {
         return new Promise((resolve, reject) => {
             getHelp("generate").then((result) => {
                 if (result && result.availableBlueprints) {
-                    this.generateChoices = result.availableBlueprints[0]["ember-cli"];
+                    this.generateChoices = result.availableBlueprints.reduce((allChoices, currentChoices) => {
+                        const newOptions = [];
+                        Object.keys(currentChoices).forEach((choiceSource) => {
+                            newOptions.push(...currentChoices[choiceSource]);
+                        });
+
+                        return [...allChoices, ...newOptions];
+                    }, []);
                     resolve();
                 } else {
                     // Todo: Handle this


### PR DESCRIPTION
The output of ember-cli for available blueprints seem to have changed around 2.6. Since then the available blueprints were split up into legacy blueprints (which I guess should be moved into ember itself at one point) and ember-clis own blueprints. This PR should include all available blueprints and fixes the problem that blueprints weren't appearing since 2.6 (which should close #22 and #21).
