### PR TITLE
Use local Ember bin

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -58,3 +58,8 @@ export function getFullAppPath(): string {
     const appPath = readSetting("appPath") || "./";
     return path.join(workspace.rootPath, appPath);
 }
+
+export function getPathToEmberBin(): string {
+    const appPath = getFullAppPath();
+    return path.join(appPath, "node_modules/.bin/ember");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,5 +61,12 @@ export function getFullAppPath(): string {
 
 export function getPathToEmberBin(): string {
     const appPath = getFullAppPath();
-    return path.join(appPath, "node_modules/.bin/ember");
+    const localEmber = path.join(appPath, "node_modules/.bin/ember");
+
+    try {
+        const stats = fs.statSync(localEmber);
+        return stats ? localEmber : "ember";
+    } catch (error) {
+        return "ember";
+    }
 }

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 
 import { capitalizeFirstLetter, semver } from "./helpers";
-import { getFullAppPath } from "./config";
+import { getFullAppPath, getPathToEmberBin } from "./config";
 
 export interface EmberOperationResult {
     code: Number;
@@ -60,6 +60,7 @@ export class EmberOperation {
 
             let lastOut = "";
             let debugEnabled = process.env.VSC_EMBER_CLI_DEBUG || process.env["VSC EMBER CLI DEBUG"];
+            let emberPath = getPathToEmberBin();
 
             this._oc = window.createOutputChannel(`Ember: ${capitalizeFirstLetter(this.cmd[0])}`);
 
@@ -67,14 +68,14 @@ export class EmberOperation {
             // https://github.com/nodejs/node-v0.x-archive/issues/2318
             if (os.platform() === "win32") {
                 let joinedArgs = this.cmd;
-                joinedArgs.unshift("ember");
+                joinedArgs.unshift(emberPath);
 
                 this._process = this._spawn("powershell.exe", joinedArgs, {
                     cwd: getFullAppPath(),
                     stdio: ["ignore", "pipe", "pipe" ]
                 });
             } else {
-                this._process = this._spawn("ember", this.cmd, {
+                this._process = this._spawn(emberPath, this.cmd, {
                     cwd: getFullAppPath()
                 });
             }
@@ -135,14 +136,20 @@ export class EmberOperation {
 }
 
 export function isEmberCliInstalled(): boolean {
+    let emberBin = getPathToEmberBin();
+
     try {
-        let exec = cp.execSync("ember -v");
+        let exec = cp.execSync(`${emberBin} -v`, {
+            cwd: getFullAppPath()
+        });
 
         console.log("Ember is apparently installed");
         console.log(exec.toString());
 
         return true;
     } catch (e) {
+        debugger;
+
         return false;
     }
 }


### PR DESCRIPTION
I'm not sure what the reason was (possibly due to using a Node version manager), but I ran into issues where the VSCode plugin didn't think I have Ember installed. Based on the assumption that every Ember app or add-on should have a version of the CLI installed in it's directory, we can use the app path to give the extension an exact path to the executable to run.

I tested this on my machine, and it cleared my issues right up. Instead of getting an error about the CLI not being installed, I not only get no error but the commands all seem to work.