### PR TITLE
Fixes Ember CLI Not Found message

### DIFF
--- a/src/ember-cli.ts
+++ b/src/ember-cli.ts
@@ -4,7 +4,7 @@ import { jsConfig } from "./constants";
 import { appendJSConfig } from "./file-ops";
 import { installTypings } from "./typing-ops";
 import { EmberOperationResult, EmberOperation } from "./ember-ops";
-import { capitalizeFirstLetter } from "./helpers";
+import { capitalizeFirstLetter, fileNameSanitation } from "./helpers";
 import DumbCache from "./dumb-cache";
 
 export class EmberCliManager {
@@ -74,6 +74,8 @@ export class EmberCliManager {
             if (!result || result === "") {
                 return;
             };
+
+            result = fileNameSanitation(result);
 
             let newOp = new EmberOperation(["new", result]);
             newOp.run();

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -151,7 +151,7 @@ function getEmberVersionDump(): string {
     let emberBin = getPathToEmberBin();
 
     try {
-        let exec = cp.execSync(`"${emberBin}" -v`, {
+        let exec = cp.execSync(`${emberBin} -v`, {
             cwd: getFullAppPath()
         });
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,3 +18,12 @@ export function semver() {
 export function versionDumpParse(): RegExp {
     return /ember-cli:\s*(.*)\s*\nnode:\s(.*)\s*\nos:\s*(.*)/ig;
 }
+
+/**
+ * lowercase and replace spaces with hyphens
+ * @param str 
+ */
+export function fileNameSanitation(str): string {
+    //return str.replace(/\s+/g, '-').toLowerCase();
+    return `"${str}"`;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,3 +5,16 @@ export function capitalizeFirstLetter(input: string) {
 export function semver() {
     return /\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b/ig;
 }
+
+/**
+ * Returns the versions from ember -v
+ * match[1] = ember version
+ * match[2] = node version
+ * match[3] = os info
+ * 
+ * @export function
+ * @returns RegExp
+ */
+export function versionDumpParse(): RegExp {
+    return /ember-cli:\s*(.*)\s*\nnode:\s(.*)\s*\nos:\s*(.*)/ig;
+}


### PR DESCRIPTION
Also fixes up an issue where getting the ember version is dependent on bower.json.
I wasn't able to create a new project.
It will use the `ember -v` to determine the version.

I'd like someone to give a quick run-through to make sure everything is still working for other environments, I'm also not certain how creating a new project should function. Do I need to reopen the project folder that was created up, but then I'm losing scope of the two files outside of the project folder; I feel like those should live inside of the project folder and that I should already be inside of it.

I get a folder structure like so: 
![image](https://cloud.githubusercontent.com/assets/416814/23932153/a378dfb0-08f3-11e7-8cf4-c144909656c1.png)
