### PR TITLE
Typings & JSConfig into new Ember App Folder

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -1,26 +1,26 @@
-import {window, commands} from "vscode";
+import { window, commands } from "vscode";
 import * as embercli from "./src/ember-cli";
 import * as emberOps from "./src/ember-ops";
 
-var emberManager : embercli.EmberCliManager;
-var installed : boolean = false;
+var emberManager: embercli.EmberCliManager;
+var installed: boolean = false;
 
 export function activate() {
     execute("setupProject");
 
     // Register Commands
-    commands.registerCommand("extension.addon", 		 () => execute("addon"));
-    commands.registerCommand("extension.setupProject", 	 () => execute("setupProject"));
-    commands.registerCommand("extension.build", 		 () => execute("build"));
-    commands.registerCommand("extension.serve", 		 () => execute("serve"));
-    commands.registerCommand("extension.init", 			 () => execute("init"));
-    commands.registerCommand("extension.new", 			 () => execute("new"));
-    commands.registerCommand("extension.install", 		 () => execute("install"));
-    commands.registerCommand("extension.generate", 		 () => execute("blueprint", ["generate"]));
-    commands.registerCommand("extension.destroy", 		 () => execute("blueprint", ["destroy"]));
-    commands.registerCommand("extension.version", 		 () => execute('version'));
-    commands.registerCommand("extension.test", 			 () => execute("test"));
-    commands.registerCommand("extension.testServer", 	 () => execute("testServer"));
+    commands.registerCommand("extension.addon", () => execute("addon"));
+    commands.registerCommand("extension.setupProject", () => execute("setupProject"));
+    commands.registerCommand("extension.build", () => execute("build"));
+    commands.registerCommand("extension.serve", () => execute("serve"));
+    commands.registerCommand("extension.init", () => execute("init"));
+    commands.registerCommand("extension.new", () => execute("new"));
+    commands.registerCommand("extension.install", () => execute("install"));
+    commands.registerCommand("extension.generate", () => execute("blueprint", ["generate"]));
+    commands.registerCommand("extension.destroy", () => execute("blueprint", ["destroy"]));
+    commands.registerCommand("extension.version", () => execute('version'));
+    commands.registerCommand("extension.test", () => execute("test"));
+    commands.registerCommand("extension.testServer", () => execute("testServer"));
     commands.registerCommand("extension.installTypings", () => execute("installTypings"));
 }
 
@@ -28,26 +28,26 @@ function execute(cmd?: string, arg?: Array<any>) {
     if (!emberManager) {
         emberManager = new embercli.EmberCliManager();
     }
-    if (!installed) {
-        installed = emberOps.isEmberCliInstalled();
-    }
 
     if (!cmd) {
         return;
     }
 
-    // Ensure Ember Cli is installed
-    if (!installed) {
-        return window.showErrorMessage('Ember Cli is not installed');
-    };
+    emberOps.isEmberCliInstalled()
+        .then(function () {
+            installed = true;
 
-    let ecmd = emberManager[cmd];
-    if (typeof ecmd === 'function') {
-        try {
-            ecmd.apply(emberManager, arg);
-        } catch (e) {
-            // Well, clearly we didn't call a function
-            console.log(e);
-        }
-    }
+            let ecmd = emberManager[cmd];
+            if (typeof ecmd === 'function') {
+                try {
+                    ecmd.apply(emberManager, arg);
+                } catch (e) {
+                    // Well, clearly we didn't call a function
+                    console.log(e);
+                }
+            }
+        })
+        .catch(function () {
+            return window.showErrorMessage('Ember Cli is not installed');
+        });
 }

--- a/extension.ts
+++ b/extension.ts
@@ -6,7 +6,7 @@ var emberManager: embercli.EmberCliManager;
 var installed: boolean = false;
 
 export function activate() {
-    execute("setupProject");
+    //execute("setupProject");
 
     // Register Commands
     commands.registerCommand("extension.addon", () => execute("addon"));

--- a/extension.ts
+++ b/extension.ts
@@ -28,26 +28,26 @@ function execute(cmd?: string, arg?: Array<any>) {
     if (!emberManager) {
         emberManager = new embercli.EmberCliManager();
     }
+    if (!installed) {
+        installed = emberOps.isEmberCliInstalled();
+    }
 
     if (!cmd) {
         return;
     }
 
-    emberOps.isEmberCliInstalled()
-        .then(function () {
-            installed = true;
+    // Ensure Ember Cli is installed
+    if (!installed) {
+        return window.showErrorMessage('Ember Cli is not installed');
+    };
 
-            let ecmd = emberManager[cmd];
-            if (typeof ecmd === 'function') {
-                try {
-                    ecmd.apply(emberManager, arg);
-                } catch (e) {
-                    // Well, clearly we didn't call a function
-                    console.log(e);
-                }
-            }
-        })
-        .catch(function () {
-            return window.showErrorMessage('Ember Cli is not installed');
-        });
+    let ecmd = emberManager[cmd];
+    if (typeof ecmd === 'function') {
+        try {
+            ecmd.apply(emberManager, arg);
+        } catch (e) {
+            // Well, clearly we didn't call a function
+            console.log(e);
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -123,8 +123,10 @@
     "vscode": "^1.0.5"
   },
   "dependencies": {
+    "cross-spawn": "^5.1.0",
     "fs-extra": "^2.0.0",
     "merge": "^1.2.0",
-    "path-exists": "^3.0.0"
+    "path-exists": "^3.0.0",
+    "superspawn": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "cross-spawn": "^5.1.0",
     "fs-extra": "^2.0.0",
     "merge": "^1.2.0",
-    "path-exists": "^3.0.0",
-    "superspawn": "^0.1.0"
+    "path-exists": "^3.0.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export function readSetting(key: string): any {
     }
 }
 
+// Unused?
 export function writeSetting(data) {
     let currentConfig, mergedConfig, newConfig;
     // Check first if a jsconfig.json exists
@@ -32,7 +33,7 @@ export function writeSetting(data) {
     // Write new config
     try {
         newConfig = mergedConfig || data;
-        fs.writeFileSync(configPath, JSON.stringify(newConfig), "utf8");
+        fs.writeFileSync(configPath, JSON.stringify(newConfig, null, "  "), "utf8");
         return true;
     } catch (e) {
         return false;

--- a/src/ember-cli.ts
+++ b/src/ember-cli.ts
@@ -4,7 +4,7 @@ import { jsConfig } from "./constants";
 import { appendJSConfig } from "./file-ops";
 import { installTypings } from "./typing-ops";
 import { EmberOperationResult, EmberOperation } from "./ember-ops";
-import { capitalizeFirstLetter } from "./helpers";
+import { capitalizeFirstLetter, fileNameSanitation } from "./helpers";
 import DumbCache from "./dumb-cache";
 
 export class EmberCliManager {
@@ -74,6 +74,8 @@ export class EmberCliManager {
             if (!result || result === "") {
                 return;
             };
+
+            result = fileNameSanitation(result);
 
             let newOp = new EmberOperation(["new", result]);
             newOp.run();

--- a/src/ember-cli.ts
+++ b/src/ember-cli.ts
@@ -35,7 +35,7 @@ export class EmberCliManager {
                 } else {
                     window.showErrorMessage("Addon folder structure creation failed.");
                 }
-        });
+            });
     }
 
     // ember version
@@ -76,8 +76,12 @@ export class EmberCliManager {
             };
 
             let newOp = new EmberOperation(["new", result]);
-            newOp.run();
-            this.setupProject();
+            newOp.run()
+                .then(() => {
+                    this.setupProject(result);
+                    // Todo: open new folder up in vscode as root;;; Maybe?
+                    // commands.executeCommand('vscode.openFolder', `./${result}`, false);
+                });
         });
     }
 
@@ -190,7 +194,7 @@ export class EmberCliManager {
                     let name = result.anonymousOptions[i];
 
                     optionPromises.push(window.showInputBox({
-                        prompt: `${capitalizeFirstLetter(name) }?`
+                        prompt: `${capitalizeFirstLetter(name)}?`
                     }).then((promptResult) => {
                         optionResults.push(promptResult);
                         gdName = (i === 1) ? promptResult : gdName;
@@ -273,23 +277,15 @@ export class EmberCliManager {
     // Helper Functions
     */
 
-    // Is the current project setup for Visual Studio Code?
-    public isProjectSetup(): boolean {
-        return false;
-    }
-
-    // Is the current project an Ember Cli project?
-    public isProjectEmberCli(): boolean {
-        return true;
-    }
-
     // Set the project up
-    public setupProject(): boolean {
+    public setupProject(path?: string): boolean {
         if (!workspace || !workspace.rootPath) {
             return false;
         }
 
-        appendJSConfig(jsConfig);
-        installTypings();
+        console.log("Setting Up Project");
+
+        appendJSConfig(jsConfig, path);
+        installTypings(path);
     }
 }

--- a/src/ember-cli.ts
+++ b/src/ember-cli.ts
@@ -4,7 +4,7 @@ import { jsConfig } from "./constants";
 import { appendJSConfig } from "./file-ops";
 import { installTypings } from "./typing-ops";
 import { EmberOperationResult, EmberOperation } from "./ember-ops";
-import { capitalizeFirstLetter, fileNameSanitation } from "./helpers";
+import { capitalizeFirstLetter } from "./helpers";
 import DumbCache from "./dumb-cache";
 
 export class EmberCliManager {
@@ -74,8 +74,6 @@ export class EmberCliManager {
             if (!result || result === "") {
                 return;
             };
-
-            result = fileNameSanitation(result);
 
             let newOp = new EmberOperation(["new", result]);
             newOp.run();

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -1,6 +1,5 @@
 import { window, workspace, OutputChannel } from "vscode";
 import * as cp from "child_process";
-import * as os from "os";
 import * as path from "path";
 
 import { capitalizeFirstLetter, semver, versionDumpParse } from "./helpers";
@@ -15,7 +14,6 @@ export interface EmberOperationResult {
 }
 
 export class EmberOperation {
-    private _spawn = cp.spawn;
     private _oc: OutputChannel;
     private _process: cp.ChildProcess;
     private _isOutputChannelVisible: boolean;
@@ -66,21 +64,10 @@ export class EmberOperation {
 
             this._oc = window.createOutputChannel(`Ember: ${capitalizeFirstLetter(this.cmd[0])}`);
 
-            // On Windows, we'll have to call Ember with PowerShell
-            // https://github.com/nodejs/node-v0.x-archive/issues/2318
-            if (os.platform() === "win32") {
-                let joinedArgs = this.cmd;
-                joinedArgs.unshift(emberPath);
+            this._process = spawn(emberPath, this.cmd, {
+                cwd: getFullAppPath()
+            });
 
-                this._process = this._spawn("powershell.exe", joinedArgs, {
-                    cwd: getFullAppPath(),
-                    stdio: ["ignore", "pipe", "pipe"]
-                });
-            } else {
-                this._process = this._spawn(emberPath, this.cmd, {
-                    cwd: getFullAppPath()
-                });
-            }
             this._oc.appendLine("Building...");
 
             if (this._isOutputChannelVisible || debugEnabled) {

--- a/src/ember-ops.ts
+++ b/src/ember-ops.ts
@@ -151,7 +151,7 @@ function getEmberVersionDump(): string {
     let emberBin = getPathToEmberBin();
 
     try {
-        let exec = cp.execSync(`"${emberBin}" -v`, {
+        let exec = cp.execSync(`${emberBin} -v`, {
             cwd: getFullAppPath()
         });
 

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -10,12 +10,12 @@ const pathExists = require("path-exists");
 const merge = require("merge");
 
 // Merges or overwrites settings in jsconfig.json
-export function appendJSConfig(data): boolean {
+export function appendJSConfig(data, filepath = ""): boolean {
     if (!workspace || !workspace.rootPath) {
         return false;
     }
 
-    let jscPath = path.join(getFullAppPath(), "jsconfig.json");
+    let jscPath = path.join(getFullAppPath(), filepath, "jsconfig.json");
     let newJsc, mergedJsc, currentJsc;
 
     // Check first if a jsconfig.json exists

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -32,7 +32,7 @@ export function appendJSConfig(data): boolean {
     // Write new config
     try {
         newJsc = mergedJsc || jsConfig;
-        fs.writeFileSync(jscPath, JSON.stringify(newJsc), "utf8");
+        fs.writeFileSync(jscPath, JSON.stringify(newJsc, null, " "), "utf8");
     } catch (e) {
         return false;
     }

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -32,7 +32,7 @@ export function appendJSConfig(data, filepath = ""): boolean {
     // Write new config
     try {
         newJsc = mergedJsc || jsConfig;
-        fs.writeFileSync(jscPath, JSON.stringify(newJsc, null, " "), "utf8");
+        fs.writeFileSync(jscPath, JSON.stringify(newJsc, null, "  "), "utf8");
     } catch (e) {
         return false;
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,12 +18,3 @@ export function semver() {
 export function versionDumpParse(): RegExp {
     return /ember-cli:\s*(.*)\s*\nnode:\s(.*)\s*\nos:\s*(.*)/ig;
 }
-
-/**
- * lowercase and replace spaces with hyphens
- * @param str 
- */
-export function fileNameSanitation(str): string {
-    //return str.replace(/\s+/g, '-').toLowerCase();
-    return `"${str}"`;
-}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,3 +18,12 @@ export function semver() {
 export function versionDumpParse(): RegExp {
     return /ember-cli:\s*(.*)\s*\nnode:\s(.*)\s*\nos:\s*(.*)/ig;
 }
+
+/**
+ * lowercase and replace spaces with hyphens
+ * @param str 
+ */
+export function fileNameSanitation(str): string {
+    //return str.replace(/\s+/g, '-').toLowerCase();
+    return `"${str}"`;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,3 +5,16 @@ export function capitalizeFirstLetter(input: string) {
 export function semver() {
     return /\bv?(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?\b/ig;
 }
+
+/**
+ * Returns the versions from ember -v
+ * match[1] = ember version
+ * match[2] = node version
+ * match[3] = os info
+ * 
+ * @export function
+ * @returns RegExp
+ */
+export function versionDumpParse(): RegExp {
+    return /ember-cli:\s*(.*)\s*\nnode:\s(.*)\s*\nos:\s*(.*)/ig;
+}

--- a/src/typing-ops.ts
+++ b/src/typing-ops.ts
@@ -8,20 +8,20 @@ import * as fs from "fs-extra";
 
 const pathExists = require("path-exists");
 
-export function installTypings(): Promise<boolean> {
+export function installTypings(filePath = ""): Promise<boolean> {
     return new Promise((resolve, reject) => {
         if (!shouldInstallTypings()) {
             return resolve();
         }
 
         return getEmberVersion()
-            .then((version) => installTypingsForVersion(version));
+            .then((version) => installTypingsForVersion(version, filePath));
     });
 }
 
-function installTypingsForVersion(version: string): Promise<boolean> {
+function installTypingsForVersion(version: string, filePath = ""): Promise<boolean> {
     return new Promise((resolve, reject) => {
-        let typingsFolder = path.join(workspace.rootPath, "typings", "ember");
+        let typingsFolder = path.join(workspace.rootPath, filePath, "typings", "ember");
         let versionTypings = path.join(__dirname, "..", "..", "resources", "typings", `v${version}`, "ember.d.ts");
         let lastTypings = path.join(__dirname, "..", "..", "resources", "typings", "v2.4.4", "ember.d.ts");
         let typings;

--- a/src/typing-ops.ts
+++ b/src/typing-ops.ts
@@ -15,13 +15,7 @@ export function installTypings(): Promise<boolean> {
         }
 
         return getEmberVersion()
-            .then((version) => {
-                return installTypingsForVersion(version);
-            })
-            .catch((e) => {
-                console.log(e);
-                debugger;
-            });
+            .then((version) => installTypingsForVersion(version));
     });
 }
 

--- a/src/typing-ops.ts
+++ b/src/typing-ops.ts
@@ -15,7 +15,13 @@ export function installTypings(): Promise<boolean> {
         }
 
         return getEmberVersion()
-            .then((version) => installTypingsForVersion(version));
+            .then((version) => {
+                return installTypingsForVersion(version);
+            })
+            .catch((e) => {
+                console.log(e);
+                debugger;
+            });
     });
 }
 


### PR DESCRIPTION
### New stuff in the correct place
When creating a new ember app the typings and JSConfig will now create in the new ember folder.

### Also removes some vestigial code
- `ember-cli.ts` isProjectSetup() & isProjectEmberCli()
    - Couldn't tell if this code did anything or was needed now?

### Areas of conflict & redundancy
- Commented out `extension.ts` execute("setupProject")
    - This was generating typings and jsconfig before the "new" command was ran thus creating them before a project existed.
- Cannot remember if I checked for any dependencies on this.

### Notes
- Branched from https://github.com/ctsstc/vsc-ember-cli/tree/cross-spawn