### PR TITLE
Add new configuration option to leave a jsconfig.json file as-is during startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,17 @@
   },
   "main": "./out/extension",
   "contributes": {
+    "configuration": {
+        "id": "vsc-ember-cli",
+        "title": "Ember CLI",
+        "properties": {
+          "vsc-ember-cli.updateJSConfig": {
+            "type": "boolean",
+            "default": true,
+            "description": "Update jsconfig.json if found in project."
+          }
+        }
+    },
     "snippets": [
       {
         "language": "handlebars",

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -20,6 +20,14 @@ export function appendJSConfig(data): boolean {
 
     // Check first if a jsconfig.json exists
     if (pathExists.sync(jscPath)) {
+		let extensionConfig = workspace.getConfiguration('vsc-ember-cli');
+
+		// If the file exists, but the user has requested no update,
+		// go ahead and return now
+		if (!extensionConfig.updateJSConfig) {
+			return false;
+		}
+
         // Merge
         try {
             currentJsc = JSON.parse(fs.readFileSync(jscPath, "utf8"));


### PR DESCRIPTION
This would resolve issue #47 by allowing users to disable the jsconfig.json update logic